### PR TITLE
use built in env() function instead of getenv

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -8,6 +8,7 @@ use GraphQL\Client;
 use GraphQL\SchemaObject\RootProjectsArgumentsObject;
 use GraphQL\SchemaObject\RootQueryObject;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\App;
 
 class UserController extends Controller
 {
@@ -42,8 +43,8 @@ class UserController extends Controller
             ->selectName()
             ->selectCreatedAt()
             ->selectNamespace()->selectName()->selectFullName();
-        $token = getenv('APP_ENV') === 'local' ? getenv('GITLAB_ACCESS_TOKEN') : auth()->user()->access_token;
-        $client = new Client(getenv('GITLAB_URL') . '/api/graphql', ["Authorization" => 'Bearer ' . $token]);
+        $token = App::environment(['local']) ? env('GITLAB_ACCESS_TOKEN') : auth()->user()->access_token;
+        $client = new Client(env('GITLAB_URL') . '/api/graphql', ["Authorization" => 'Bearer ' . $token]);
 
         // @phpstan-ignore-next-line
         return new \Illuminate\Support\Collection($client->runQuery($rootObject)->getResults()->data->projects->nodes);

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -83,7 +83,7 @@ class CourseController extends Controller
         $courseNameSlug = Str::slug($validated['course-name']);
 
         // Check if group already exists in GitLab.
-        $currentGroup = $manager->groups()->subgroups(getenv('GITLAB_GROUP'), ['search' => $courseNameSlug]);
+        $currentGroup = $manager->groups()->subgroups(env('GITLAB_GROUP'), ['search' => $courseNameSlug]);
         if(count($currentGroup) > 0)
             return redirect()->back()->withErrors(['course-name' => 'A course with that name already exists in GitLab.'])->withInput();
 
@@ -91,7 +91,7 @@ class CourseController extends Controller
             'name'       => $validated['course-name'],
             'path'       => $courseNameSlug,
             'visibility' => 'private',
-            'parent_id'  => getenv('GITLAB_GROUP'),
+            'parent_id'  => env('GITLAB_GROUP'),
         ];
 
         // Create new gitlab subgroup under parent group.

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -172,7 +172,7 @@ class ProjectController extends Controller
                 ->selectNodes()
                 ->selectName()
                 ->selectSha();
-            $client = new Client('https://gitlab.sdu.dk/api/graphql', ["Authorization" => 'Bearer ' . getenv('GITLAB_ACCESS_TOKEN')]);
+            $client = new Client('https://gitlab.sdu.dk/api/graphql', ["Authorization" => 'Bearer ' . env('GITLAB_ACCESS_TOKEN')]);
             $projects = $client->runQuery($rootObject->getQuery())->getResults()->data->projects->nodes; // @phpstan-ignore-line
 
             if(count($projects) == 0)

--- a/app/Http/Middleware/BasicAuthForStaging.php
+++ b/app/Http/Middleware/BasicAuthForStaging.php
@@ -24,8 +24,8 @@ class BasicAuthForStaging
 
         if($request->server('PHP_AUTH_USER') && $request->server('PHP_AUTH_PW'))
         {
-            if ( ! ($request->server('PHP_AUTH_USER') == getenv('STAGING_USER') &&
-                $request->server('PHP_AUTH_PW') == getenv('STAGING_PASS')))
+            if ( ! ($request->server('PHP_AUTH_USER') == env('STAGING_USER') &&
+                $request->server('PHP_AUTH_PW') == env('STAGING_PASS')))
                 $this->basic();
             session()->put('staging-authed', true);
 

--- a/app/Listeners/GitLab/Project/RegisterWebhook.php
+++ b/app/Listeners/GitLab/Project/RegisterWebhook.php
@@ -46,7 +46,7 @@ class RegisterWebhook implements ShouldQueue
         $currentHooks = new Collection($manager->projects()->hooks($event->project->gitlab_project_id));
         if($currentHooks->isEmpty())
         {
-            $webhookUrl = getenv('GITLAB_WEBHOOK_URL');
+            $webhookUrl = env('GITLAB_WEBHOOK_URL');
             $response = $manager->projects()->addHook($event->project->gitlab_project_id, $webhookUrl, [
                 'pipeline_events'         => true,
                 'token'                   => Project::token($event->project),

--- a/domain/GitLab/Actions/GitLabActions.php
+++ b/domain/GitLab/Actions/GitLabActions.php
@@ -44,7 +44,7 @@ class GitLabActions implements SourceControl
             ->selectTree()
             ->selectLastCommit()
             ->selectSha();
-        $client = new Client(getenv('GITLAB_URL') . '/api/graphql', ["Authorization" => 'Bearer ' . $token]);
+        $client = new Client(env('GITLAB_URL') . '/api/graphql', ["Authorization" => 'Bearer ' . $token]);
 
         $projects = $client->runQuery($rootObject)->getResults()->data->projects->nodes; // @phpstan-ignore-line
         if(count($projects) == 0)
@@ -64,7 +64,7 @@ class GitLabActions implements SourceControl
             ->selectName()
             ->selectId();
 
-        $client = new Client(getenv('GITLAB_URL') . '/api/graphql', ["Authorization" => 'Bearer ' . User::token($user)]);
+        $client = new Client(env('GITLAB_URL') . '/api/graphql', ["Authorization" => 'Bearer ' . User::token($user)]);
         $user = $client->runQuery($rootObject)->getResults()->data->currentUser; // @phpstan-ignore-line
 
         return new User($user->id, $user->name);
@@ -146,7 +146,7 @@ class GitLabActions implements SourceControl
                 ->selectName()
                 ->selectSha();
         });
-        $client = new Client(getenv('GITLAB_URL') . '/api/graphql', ["Authorization" => 'Bearer ' . config('scalable.gitlab_token')]);
+        $client = new Client(env('GITLAB_URL') . '/api/graphql', ["Authorization" => 'Bearer ' . config('scalable.gitlab_token')]);
         $directoryAndFiles = (array)$client->runQuery($rootObject)->getResults()->data->projects->nodes[0]->repository; // @phpstan-ignore-line
         $directoryCollection->directories->reject(fn(Directory $directory) => $directory->fetched)->each(function(Directory $directory) use ($directoryAndFiles) {
             $queryPath = $directory->graphQlSanitized()->replace("/", "_")->toString();


### PR DESCRIPTION
I saw an issue where the repository picker would not load, because of missing gitlab_url env variable.

This way fixes it and also aligns closer to laravel standards.