### PR TITLE
add job to unprotect default branch once repo is created/forked

### DIFF
--- a/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
+++ b/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Listeners\GitLab\Project;
+
+use App\Events\ProjectCreated;
+use Exception;
+use GrahamCampbell\GitLab\GitLabManager;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
+
+class UnprotectDefaultBranch implements ShouldQueue
+{
+    public int $delay = 5;
+
+    public int $tries = 5;
+
+    /**
+     * @var int[]
+     */
+    public array $backoff = [10, 30];
+
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param ProjectCreated $event
+     * @return void
+     * @throws Exception
+     */
+    public function handle(ProjectCreated $event): void
+    {
+        if ( ! $event->project->task->isCodeTask()) return;
+
+        Log::info("Unprotecting default branch for project {$event->project->id}");
+
+        $gitLabManager = app(GitLabManager::class);
+
+        $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
+        if($project['import_error'] != null || $project['import_status'] != 'finished')
+            throw new Exception("Import not fully done yet.");
+
+        $gitLabManager->repositories()->unprotectBranch($event->project->gitlab_project_id, $project['default_branch']);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Events\ProjectCreated;
 use App\Listeners\GitLab\Project\DisableForking;
 use App\Listeners\GitLab\Project\RegisterWebhook;
+use App\Listeners\GitLab\Project\UnprotectDefaultBranch;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -22,6 +23,7 @@ class EventServiceProvider extends ServiceProvider
         ProjectCreated::class => [
             DisableForking::class,
             RegisterWebhook::class,
+            UnprotectDefaultBranch::class,
         ],
     ];
 

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -4,6 +4,7 @@ use App\Events\ProjectCreated;
 use App\Listeners\GitLab\Project\DisableForking;
 use App\Jobs\Project\RefreshMemberAccess;
 use App\Listeners\GitLab\Project\RegisterWebhook;
+use App\Listeners\GitLab\Project\UnprotectDefaultBranch;
 use App\Models\Course;
 use App\Models\Project;
 use App\Models\Task;
@@ -47,4 +48,11 @@ it('ensures the RegisterWebhook event is fired when ProjectCreated', function() 
     Project::factory()->for(Task::factory()->for(Course::factory()))->create();
 
     Event::assertListening(ProjectCreated::class, RegisterWebhook::class);
+});
+
+it('ensures the UnprotectDefaultBranch event is fired when ProjectCreated is triggered', function() {
+    Event::fake();
+    Project::factory()->for(Task::factory()->for(Course::factory()))->create();
+
+    Event::assertListening(ProjectCreated::class, UnprotectDefaultBranch::class);
 });

--- a/tests/Unit/App/Jobs/UnprotectDefaultBranchJobTest.php
+++ b/tests/Unit/App/Jobs/UnprotectDefaultBranchJobTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Events\ProjectCreated;
+use App\Listeners\GitLab\Project\UnprotectDefaultBranch;
+use App\Models\Course;
+use App\Models\Project;
+use App\Models\Task;
+use App\Modules\LinkRepository\LinkRepository;
+use Carbon\Carbon;
+use GrahamCampbell\GitLab\GitLabManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery\MockInterface;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function() {
+
+    /** @var Task $task */
+    $task = Task::factory([
+        'starts_at' => Carbon::create(2022, 8, 8, 12),
+        'ends_at'   => Carbon::create(2022, 8, 24, 23, 59),
+    ])->for(Course::factory())->make();
+
+    installLinkRepositoryModule($task);
+    $task->save();
+    $this->task = $task;
+
+    $this->project = Project::factory([
+        "task_id" => $task,
+    ])->createQuietly();
+});
+
+it('should skip if the project is not a code task', function() {
+
+    $this->project->task->module_configuration->uninstall($this->project->task->module_configuration->resolveModule(LinkRepository::class));
+    $this->project->task->save();
+
+    $job = new UnprotectDefaultBranch();
+    $job->handle(new ProjectCreated($this->project));
+
+    $this->mock(GitLabManager::class, function (MockInterface $mock) {
+        $mock->shouldNotHaveBeenCalled();
+    });
+});
+
+
+it('should throw an exception if the project import is not finished', function() {
+
+    $this->project->gitlab_project_id = 1;
+    $this->project->save();
+
+    $this->mock(GitLabManager::class, function (MockInterface $mock) {
+        $mock->shouldReceive('projects->show')->once()->andReturn([
+            'import_error'  => 'error',
+            'import_status' => 'finished',
+        ]);
+    });
+
+    $this->expectException(Exception::class);
+
+    $job = new UnprotectDefaultBranch();
+    $job->handle(new ProjectCreated($this->project));
+});
+
+it('should unprotect the default branch', function() {
+
+    $this->project->gitlab_project_id = 1;
+    $this->project->save();
+
+    $this->mock(GitLabManager::class, function (MockInterface $mock) {
+        $mock->shouldReceive('projects->show')->once()->andReturn([
+            'import_error'   => null,
+            'import_status'  => 'finished',
+            'default_branch' => 'master',
+        ]);
+
+        $mock->shouldReceive('repositories->unprotectBranch')->once()->with(1, 'master');
+    });
+
+    $job = new UnprotectDefaultBranch();
+    $job->handle(new ProjectCreated($this->project));
+});
+
+


### PR DESCRIPTION
Got another ask from Aslak about repos being protected when forked on their default branch.

Since the tool is for use in first semester where people may have little to no knowledge of git, gitlab or github - they don't know what to do when met with access denied due to protected branches.