### PR TITLE
only pick up visible tasks when running mark expired

### DIFF
--- a/app/Console/Commands/MarkExpiredProjects.php
+++ b/app/Console/Commands/MarkExpiredProjects.php
@@ -39,8 +39,9 @@ class MarkExpiredProjects extends Command
      */
     public function handle() : int
     {
+        $tasks = Task::where('is_visible', true)->get();
         /** @var Task $task */
-        foreach (Task::all() as $task)
+        foreach ($tasks as $task)
         {
             $this->info("Marking tasks under [{$task->course->name}] $task->name");
             $overDueTime = $task->ends_at->addMinutes(5);

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,10 +33,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        $schedule->command('tasks:mark-expired')->everyFiveMinutes();
-        $schedule->command('tasks:delegate')->everyFifteenMinutes();
-        $schedule->command('pipelines:refresh-stale')->everyThirtyMinutes();
-        $schedule->command('tasks:preload')->everyThirtyMinutes();
+        $schedule->command('tasks:mark-expired')->everyFiveMinutes()->sendOutputTo(storage_path('logs/tasks-mark-expired.log'));
+        $schedule->command('tasks:delegate')->everyFifteenMinutes()->sendOutputTo(storage_path('logs/tasks-delegate.log'));
+        $schedule->command('pipelines:refresh-stale')->everyThirtyMinutes()->sendOutputTo(storage_path('logs/pipelines-refresh-stale.log'));
+        $schedule->command('tasks:preload')->everyThirtyMinutes()->sendOutputTo(storage_path('logs/tasks-preload.log'));
     }
 
     /**


### PR DESCRIPTION
For the scheduled command `mark expired projects` it was picking up all tasks, not only those "active" aka. visible to the students.

This PR fixes that, and also sends the log output of the most recent command execution to a file, so the output can be observed.