### PR TITLE
Ensuring propper access to repositories in none-template code tasks

### DIFF
--- a/app/Jobs/Project/RefreshMemberAccess.php
+++ b/app/Jobs/Project/RefreshMemberAccess.php
@@ -40,7 +40,7 @@ class RefreshMemberAccess implements ShouldQueue
 
     public function handle() : void
     {
-        if ( ! $this->project->task->isCodeTask()) return;
+        if ( ! $this->project->task->isTemplateTask()) return;
 
         $gitLabManager = app(GitLabManager::class);
 

--- a/app/Listeners/GitLab/Project/DisableForking.php
+++ b/app/Listeners/GitLab/Project/DisableForking.php
@@ -39,7 +39,7 @@ class DisableForking implements ShouldQueue
      */
     public function handle(ProjectCreated $event)
     {
-        if ( ! $event->project->task->isCodeTask()) return;
+        if ( ! $event->project->task->isTemplateTask()) return;
 
         Log::info("Disabling GitLab forking for project {$event->project->id}");
 

--- a/app/Listeners/GitLab/Project/DisableForking.php
+++ b/app/Listeners/GitLab/Project/DisableForking.php
@@ -45,8 +45,8 @@ class DisableForking implements ShouldQueue
 
         $attempts = 3;
         $gitLabManager = app(GitLabManager::class);
-        do{ // The system is sometimes too fast for the Gitlab server,
-            // this buys the Gitlab server some more time before Scalable moves on.
+        do // The system is sometimes too fast for the Gitlab server,
+        {  // this buys the Gitlab server some more time before Scalable moves on.
             usleep(100000);
             $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
             $attempts--;

--- a/app/Listeners/GitLab/Project/DisableForking.php
+++ b/app/Listeners/GitLab/Project/DisableForking.php
@@ -43,9 +43,15 @@ class DisableForking implements ShouldQueue
 
         Log::info("Disabling GitLab forking for project {$event->project->id}");
 
+        $attempts = 3;
         $gitLabManager = app(GitLabManager::class);
+        do{ // The system is sometimes too fast for the Gitlab server,
+            // this buys the Gitlab server some more time before Scalable moves on.
+            usleep(100000);
+            $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
+            $attempts--;
+        } while (($project['import_error'] != null || $project['import_status'] != 'finished') && $attempts > 0);
 
-        $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
         if($project['import_error'] != null || $project['import_status'] != 'finished')
             throw new Exception("Import not fully done yet.");
 

--- a/app/Listeners/GitLab/Project/RegisterWebhook.php
+++ b/app/Listeners/GitLab/Project/RegisterWebhook.php
@@ -37,7 +37,7 @@ class RegisterWebhook implements ShouldQueue
      */
     public function handle(ProjectCreated $event)
     {
-        if ( ! $event->project->task->isCodeTask())
+        if ( ! $event->project->task->isTemplateTask())
         {
             return;
         }

--- a/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
+++ b/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
@@ -45,8 +45,8 @@ class UnprotectDefaultBranch implements ShouldQueue
         $gitLabManager = app(GitLabManager::class);
 
         $attempts = 3;
-        do{ // The system is sometimes too fast for the Gitlab server,
-            // this buys the Gitlab server some more time before Scalable moves on.
+        do // The system is sometimes too fast for the Gitlab server,
+        {  // this buys the Gitlab server some more time before Scalable moves on.
             usleep(100000);
             $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
             $attempts--;

--- a/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
+++ b/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
@@ -44,7 +44,14 @@ class UnprotectDefaultBranch implements ShouldQueue
 
         $gitLabManager = app(GitLabManager::class);
 
-        $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
+        $attempts = 3;
+        do{ // The system is sometimes too fast for the Gitlab server,
+            // this buys the Gitlab server some more time before Scalable moves on.
+            usleep(100000);
+            $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
+            $attempts--;
+        } while (($project['import_error'] != null || $project['import_status'] != 'finished') && $attempts > 0);
+
         if($project['import_error'] != null || $project['import_status'] != 'finished')
             throw new Exception("Import not fully done yet.");
 

--- a/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
+++ b/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
@@ -38,7 +38,7 @@ class UnprotectDefaultBranch implements ShouldQueue
      */
     public function handle(ProjectCreated $event): void
     {
-        if ( ! $event->project->task->isCodeTask()) return;
+        if ( ! $event->project->task->isTemplateTask()) return;
 
         Log::info("Unprotecting default branch for project {$event->project->id}");
 

--- a/app/Models/Pipeline.php
+++ b/app/Models/Pipeline.php
@@ -153,7 +153,7 @@ class Pipeline extends Model
             /** @var (ProjectSubTask|null)[] $subTasksToCreate */
             $subTasksToCreate = array_map(function ($build) use ($tracking) {
                 /** @var SubTask|null $subTask */
-                $subTask = $tracking->get($build);
+                $subTask = $tracking->get(strtolower($build));
 
                 if ( ! $subTask)
                 {

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -665,7 +665,8 @@ class Task extends Model
             ]);
         } else
         {
-            if ($this->isCodeTask() && $owner != null){
+            if ($this->isCodeTask() && $owner != null)
+            {
                 $projectId = $this->getGitlabProjectId();
                 $manager = app(GitLabManager::class);
 
@@ -675,6 +676,7 @@ class Task extends Model
                 'task_id'   => $this->id,
             ]);
         }
+
         return $dbProject;
     }
 
@@ -842,20 +844,25 @@ class Task extends Model
      */
     private function addMembersToProject(User|Group $owner, GitLabManager $manager, int $projectId, int $accessLevel): void
     {
-        try {
-            if ($owner instanceof Group) {
+        try
+        {
+            if ($owner instanceof Group)
+            {
                 Log::info("Adding members of group $owner->name to project $projectId");
                 $members = $owner->members()->get();
-                foreach ($members as $member) {
+                foreach ($members as $member)
+                {
                     $response = $manager->projects()->addMember($projectId, $member->gitlab_id, $accessLevel);
                     log::info("Successfully added member $member->gitlab_id to project $projectId");
                 }
-            } elseif ($owner instanceof User) {
+            } elseif ($owner instanceof User)
+            {
                 Log::info("Adding user $owner->projectName to project $projectId");
                 $response = $manager->projects()->addMember($projectId, $owner->gitlab_id, $accessLevel);
                 log::info("Successfully added user $owner->projectName to project $projectId");
             }
-        } catch (HttpException $e) {
+        } catch (HttpException $e)
+        {
             throw new Exception("Failed adding owner $owner->name, with id GitLab id $owner->gitlab_id to project $projectId - Error: " . $e->getMessage());
         }
     }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -646,15 +646,12 @@ class Task extends Model
             $projectName = $owner == null ? Str::slug("$this->name-" . Str::random(8)) : $owner->projectName;
             $project = $projects->firstWhere('name', $projectName);
 
-            abort_unless($this->isTemplateTask(), 400, 'The template module is not enabled.');
-            $linkRepositoryModule = $this->module_configuration->resolveModule(LinkRepository::class);
-            /** @var LinkRepositorySettings $settings */
-            $settings = $linkRepositoryModule->settings();
+
             if ($project == null)
             {
-                $linkedRepositoryParts = explode('/', $settings->repo);
-                $projectId = (int)$linkedRepositoryParts[sizeof($linkedRepositoryParts) - 1]; // Get the last part, which is the Gitlab project id.
+                $projectId = $this->getGitlabProjectId();
                 $project = $this->forkProject($manager, $projectName, $projectId, $this->gitlab_group_id);
+
             }
 
             /** @var Project $dbProject */
@@ -668,13 +665,16 @@ class Task extends Model
             ]);
         } else
         {
+            if ($this->isCodeTask() && $owner != null){
+                $projectId = $this->getGitlabProjectId();
+                $manager = app(GitLabManager::class);
+
+                $this->addMembersToProject($owner, $manager, $projectId, 20);  // 20 is "Planner" level which gives them access to view and pull code but no more  https://docs.gitlab.com/ee/api/access_requests.html
+            }
             $dbProject = $owner->projects()->updateOrCreate([
                 'task_id'   => $this->id,
             ]);
         }
-
-
-
         return $dbProject;
     }
 
@@ -702,7 +702,7 @@ class Task extends Model
             'name'                   => $username,
             'path'                   => $username,
             'namespace'              => $groupId,
-            'branches'               => $sourceProject['default_branch'], // Only include the default branch.
+            //'branches'               => $sourceProject['default_branch'], // Only include the default branch.
         ];
 
         try
@@ -833,4 +833,30 @@ class Task extends Model
         return intval($project_id);
     }
 
+    /**
+     * @param User|Group $owner
+     * @param GitLabManager $manager
+     * @param int $projectId
+     * @return void
+     * @throws Exception
+     */
+    private function addMembersToProject(User|Group $owner, GitLabManager $manager, int $projectId, int $accessLevel): void
+    {
+        try {
+            if ($owner instanceof Group) {
+                Log::info("Adding members of group $owner->name to project $projectId");
+                $members = $owner->members()->get();
+                foreach ($members as $member) {
+                    $response = $manager->projects()->addMember($projectId, $member->gitlab_id, $accessLevel);
+                    log::info("Successfully added member $member->gitlab_id to project $projectId");
+                }
+            } elseif ($owner instanceof User) {
+                Log::info("Adding user $owner->projectName to project $projectId");
+                $response = $manager->projects()->addMember($projectId, $owner->gitlab_id, $accessLevel);
+                log::info("Successfully added user $owner->projectName to project $projectId");
+            }
+        } catch (HttpException $e) {
+            throw new Exception("Failed adding owner $owner->name, with id GitLab id $owner->gitlab_id to project $projectId - Error: " . $e->getMessage());
+        }
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-version: '3.8'
-
-
 services:
     database:
         image: mysql:latest

--- a/resources/js/components/Task/Tabs/Settings.vue
+++ b/resources/js/components/Task/Tabs/Settings.vue
@@ -4,7 +4,13 @@
             class="bg-white p-4 rounded-md shadow-md dark:bg-gray-800">
             <h2 class="dark:text-white font-semibold text-2xl">Settings</h2>
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <div v-if="project.ownable_type === 'App\\Models\\Group' && this.isCodeTask">
+                <div>
+                    <div v-if="!this.isTemplateTask" class="border-2 rounded-xl p-4 mt-6 border-lime-green-400 relative">
+                        <h3 class="absolute text-lime-green-400 -my-8 -ml-2 bg-white dark:bg-gray-800 px-2"></h3>
+                        <p class="text-gray-600 dark:text-gray-100">There are not settings for this type of project</p>
+                    </div>
+                </div>
+                <div v-if="project.ownable_type === 'App\\Models\\Group' && this.isTemplateTask">
                     <div class="border-2 rounded-xl p-4 mt-6 border-lime-green-400 relative">
                         <h3 class="absolute text-lime-green-400 -my-8 -ml-2 bg-white dark:bg-gray-800 px-2">Repository
                             Access</h3>
@@ -17,7 +23,7 @@
                     </div>
                 </div>
                 <div>
-                    <div class="border-2 rounded-xl p-4 mt-6 border-lime-green-400 relative">
+                    <div v-if="this.isTemplateTask" class="border-2 rounded-xl p-4 mt-6 border-lime-green-400 relative">
                         <h3 class="absolute text-lime-green-400 -my-8 -ml-2 bg-white dark:bg-gray-800 px-2">Start
                             over</h3>
                         <p class="text-gray-600 dark:text-gray-100">If you wish, you can delete your project here.
@@ -33,7 +39,7 @@
                             reset.</p>
                     </div>
                 </div>
-                <div v-if="project.ownable_type === 'App\\Models\\User' && this.isCodeTask">
+                <div v-if="project.ownable_type === 'App\\Models\\User' && this.isTemplateTask">
                     <div class="border-2 rounded-xl p-4 mt-6 border-lime-green-400 relative">
                         <h3 class="absolute text-lime-green-400 -my-8 -ml-2 bg-white dark:bg-gray-800 px-2">Migrate to
                             group</h3>
@@ -76,7 +82,7 @@ import GroupBox from "../../GroupBox";
 
 export default {
     components: {GroupBox, Alert},
-    props: ['project', 'groups', 'isCodeTask'],
+    props: ['project', 'groups', 'isTemplateTask'],
     data: function () {
         return {
             showResetWarning: false,

--- a/resources/js/components/Task/Task.vue
+++ b/resources/js/components/Task/Task.vue
@@ -162,7 +162,7 @@
                     <build-table :project-id="project.id" v-if="project != null"></build-table>
                 </div>
                 <div v-show="tab === 'settings'">
-                    <settings :groups="groups" :project="project" :is-code-task="this.isCodeTask" v-if="project != null"></settings>
+                    <settings :groups="groups" :project="project" :is-template-task="this.isTemplateTask" v-if="project != null"></settings>
                 </div>
             </div>
             <div class="w-full lg:w-1/3 mt-4 mb-4">

--- a/resources/views/tasks/show.blade.php
+++ b/resources/views/tasks/show.blade.php
@@ -7,7 +7,7 @@
               edit-route="{{ route('courses.tasks.admin.preferences', [$course, $task]) }}"
           @endcan
           code-route="{{ $codeRoute }}"
-          source_project_id="{{ $task->getGitlabProjectId() }}"
+          source_project_id="{{ $task->isCodeTask() ? $task->getGitlabProjectId() : null }}"
           :grade="{{ $task->grade(auth()->user()) ?? 'null' }}"
           :survey="{{ json_encode($survey) }}"
           :sub-tasks="{{ json_encode($subTasks) }}" :project="{{ is_null($project) ? 'null' : $project}}"

--- a/tests/Feature/GitLab/Stubs/Pipeline1.json
+++ b/tests/Feature/GitLab/Stubs/Pipeline1.json
@@ -56,7 +56,7 @@
         {
             "id": 2030891607,
             "stage": "test",
-            "name": "test 9 equals [5,2,2]",
+            "name": "Test 9 equals [5,2,2]",
             "status": "created",
             "created_at": "2022-01-29 12:58:36 UTC",
             "started_at": null,

--- a/tests/Unit/App/Jobs/DisableForkingJobTest.php
+++ b/tests/Unit/App/Jobs/DisableForkingJobTest.php
@@ -5,6 +5,7 @@ use App\Listeners\GitLab\Project\DisableForking;
 use App\Models\Course;
 use App\Models\Project;
 use App\Models\Task;
+use App\Modules\Template\Template;
 use Carbon\Carbon;
 use GrahamCampbell\GitLab\GitLabManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -21,6 +22,7 @@ beforeEach(function() {
     ])->for(Course::factory())->make();
 
     installLinkRepositoryModule($task);
+    installTemplateModule($task);
     $task->save();
     $this->task = $task;
 
@@ -29,9 +31,9 @@ beforeEach(function() {
     ])->createQuietly();
 });
 
-it('should skip if the project is not a code task', function() {
+it('should skip if the project is not a template task', function() {
 
-    $this->project->task->module_configuration->uninstall($this->project->task->module_configuration->resolveModule(LinkRepository::class));
+    $this->project->task->module_configuration->uninstall($this->project->task->module_configuration->resolveModule(Template::class));
     $this->project->task->save();
 
     $job = new DisableForking();

--- a/tests/Unit/App/Jobs/DisableForkingJobTest.php
+++ b/tests/Unit/App/Jobs/DisableForkingJobTest.php
@@ -1,11 +1,10 @@
 <?php
 
 use App\Events\ProjectCreated;
-use App\Listeners\GitLab\Project\UnprotectDefaultBranch;
+use App\Listeners\GitLab\Project\DisableForking;
 use App\Models\Course;
 use App\Models\Project;
 use App\Models\Task;
-use App\Modules\LinkRepository\LinkRepository;
 use Carbon\Carbon;
 use GrahamCampbell\GitLab\GitLabManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -35,14 +34,13 @@ it('should skip if the project is not a code task', function() {
     $this->project->task->module_configuration->uninstall($this->project->task->module_configuration->resolveModule(LinkRepository::class));
     $this->project->task->save();
 
-    $job = new UnprotectDefaultBranch();
+    $job = new DisableForking();
     $job->handle(new ProjectCreated($this->project));
 
     $this->mock(GitLabManager::class, function (MockInterface $mock) {
         $mock->shouldNotHaveBeenCalled();
     });
 });
-
 
 it('should throw an exception if the project import is not finished after 3 attempts', function() {
 
@@ -58,11 +56,11 @@ it('should throw an exception if the project import is not finished after 3 atte
 
     $this->expectException(Exception::class);
 
-    $job = new UnprotectDefaultBranch();
+    $job = new DisableForking();
     $job->handle(new ProjectCreated($this->project));
 });
 
-it('should unprotect the default branch', function() {
+it('should disable forking of the repository', function() {
 
     $this->project->gitlab_project_id = 1;
     $this->project->save();
@@ -71,14 +69,11 @@ it('should unprotect the default branch', function() {
         $mock->shouldReceive('projects->show')->once()->andReturn([
             'import_error'   => null,
             'import_status'  => 'finished',
-            'default_branch' => 'master',
         ]);
 
-        $mock->shouldReceive('repositories->unprotectBranch')->once()->with(1, 'master');
+        $mock->shouldReceive('projects->update')->once()->with(1, ['forking_access_level' => 'disabled']);
     });
 
-    $job = new UnprotectDefaultBranch();
+    $job = new DisableForking();
     $job->handle(new ProjectCreated($this->project));
 });
-
-

--- a/tests/Unit/App/Jobs/UnprotectDefaultBranchJobTest.php
+++ b/tests/Unit/App/Jobs/UnprotectDefaultBranchJobTest.php
@@ -6,6 +6,7 @@ use App\Models\Course;
 use App\Models\Project;
 use App\Models\Task;
 use App\Modules\LinkRepository\LinkRepository;
+use App\Modules\Template\Template;
 use Carbon\Carbon;
 use GrahamCampbell\GitLab\GitLabManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -22,6 +23,7 @@ beforeEach(function() {
     ])->for(Course::factory())->make();
 
     installLinkRepositoryModule($task);
+    installTemplateModule($task);
     $task->save();
     $this->task = $task;
 
@@ -30,9 +32,9 @@ beforeEach(function() {
     ])->createQuietly();
 });
 
-it('should skip if the project is not a code task', function() {
+it('should skip if the project is not a template task', function() {
 
-    $this->project->task->module_configuration->uninstall($this->project->task->module_configuration->resolveModule(LinkRepository::class));
+    $this->project->task->module_configuration->uninstall($this->project->task->module_configuration->resolveModule(Template::class));
     $this->project->task->save();
 
     $job = new UnprotectDefaultBranch();

--- a/tests/Unit/App/Models/TaskTest.php
+++ b/tests/Unit/App/Models/TaskTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Models;
+
+use App\Models\Course;
+use App\Models\Group;
+use App\Models\Task;
+use App\Models\User;
+use App\Modules\LinkRepository\LinkRepository;
+use App\Modules\LinkRepository\LinkRepositorySettings;
+use Carbon\Carbon;
+use Gitlab\Api\Projects;
+use GrahamCampbell\GitLab\GitLabManager;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Queue;
+use Mockery;
+use Tests\TestCase;
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function() {
+    $this->course = Course::factory()->create();
+    $this->task = Task::factory([
+        'starts_at' => Carbon::create(2022, 8, 8, 12),
+        'ends_at'   => Carbon::create(2022, 8, 24, 23, 59, 59),
+    ])->for($this->course)->create();
+    $this->user = User::factory()->hasAttached($this->course)->create();
+    Carbon::setTestNow(Carbon::create(2022, 8, 16));
+});
+
+it('returns null if LinkRepository module is not enabled', function () {
+    expect($this->task->getGitlabProjectId())->toBeNull();
+});
+
+it('returns the correct ID of the gitlab project', function () {
+    addLinkToRepositoryModule($this);
+
+    expect($this->task->getGitlabProjectId())->toBe(9033);
+});
+
+it('adds user to template repository if task is a "code task"', function () {
+    addLinkToRepositoryModule($this);
+    expect($this->task->isCodeTask())->toBeTrue();
+
+    $user = User::factory()->create();
+
+    // Mock GitLabManager & Projects
+    $mockGitLabManager = Mockery::mock(GitLabManager::class);
+    $mockProjects = Mockery::mock(Projects::class);
+
+    // Ensure that `projects()` method returns the mock
+    $mockGitLabManager->shouldReceive('projects')
+        ->andReturn($mockProjects);
+
+    // Mock `addMember` before execution
+    $mockProjects->shouldReceive('addMember')
+        ->with('9033', $user->gitlab_id, 20)
+        ->once()
+        ->andReturnNull();  // Prevent actual execution
+
+    // Make Laravel use the mocked instance
+    app()->instance(GitLabManager::class, $mockGitLabManager);
+
+    // Act
+    $this->task->createProject($user);
+    assertDatabaseHas('projects', [
+        'task_id'              => $this->task->id,
+        'ownable_type'         => 'App\Models\User',
+        'ownable_id'           => $user->id,
+    ]);
+});
+
+it('adds all users of a group to template repository if task is a "code task"', function () {
+    addLinkToRepositoryModule($this);
+    expect($this->task->isCodeTask())->toBeTrue();
+    $group = Group::factory([
+        'name'      => 'Example Group',
+    ])->for($this->course)->create();
+
+    // Create four users
+    $users = User::factory()->count(4)->create();
+
+    // Attach users to the group
+    $group->members()->attach($users);
+
+    // Mock GitLabManager & Projects
+    $mockGitLabManager = Mockery::mock(GitLabManager::class);
+    $mockProjects = Mockery::mock(Projects::class);
+
+    // Ensure that `projects()` method returns the mock
+    $mockGitLabManager->shouldReceive('projects')
+        ->andReturn($mockProjects);
+
+    // Mock `addMember` before execution
+    $mockProjects->shouldReceive('addMember')
+        ->with('9033', Mockery::any(), 20)
+        ->times(4)
+        ->andReturnNull();  // Prevent actual execution
+
+    // Make Laravel use the mocked instance
+    app()->instance(GitLabManager::class, $mockGitLabManager);
+
+    // Act
+    $this->task->createProject($group);
+
+    assertDatabaseHas('projects', [
+        'task_id'              => $this->task->id,
+        'ownable_type'         => 'App\Models\Group',
+        'ownable_id'           => $group->id,
+    ]);
+});
+
+/**
+ * @param \PHPUnit\Framework\TestCase $that
+ * @return void
+ */
+function addLinkToRepositoryModule(\PHPUnit\Framework\TestCase $that): void
+{
+    $that->task->module_configuration->addModule(LinkRepository::class);
+    $settings = new LinkRepositorySettings();
+    $settings->repo = "id://gitlab/Project/9033";
+    $that->task->module_configuration->update(LinkRepository::class, $settings, $that->task);
+    $that->task->module_configuration->resolveModule(LinkRepository::class)->update($that->task);
+}

--- a/tests/Unit/App/Models/TaskTest.php
+++ b/tests/Unit/App/Models/TaskTest.php
@@ -11,6 +11,7 @@ use App\Modules\LinkRepository\LinkRepositorySettings;
 use Carbon\Carbon;
 use Gitlab\Api\Projects;
 use GrahamCampbell\GitLab\GitLabManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -20,14 +21,12 @@ use Tests\TestCase;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
 
+uses(RefreshDatabase::class);
+
 beforeEach(function() {
     $this->course = Course::factory()->create();
-    $this->task = Task::factory([
-        'starts_at' => Carbon::create(2022, 8, 8, 12),
-        'ends_at'   => Carbon::create(2022, 8, 24, 23, 59, 59),
-    ])->for($this->course)->create();
+    $this->task = Task::factory()->for($this->course)->create();
     $this->user = User::factory()->hasAttached($this->course)->create();
-    Carbon::setTestNow(Carbon::create(2022, 8, 16));
 });
 
 it('returns null if LinkRepository module is not enabled', function () {


### PR DESCRIPTION
This PR:
 - Adds functionallity to add users to the template repository in tasks where only the LinkReopsitory module is used (as a counter to when the Template module is also used)

 - Updated the "project creation pipeline" (consisding of a serise of Jobs listening to project creating events) to react to when the Template module is active and not the LinkRepository module

 - Did some general house cleaning, removing the, now deprecated, "version" tag from the docker-compose file