### PR TITLE
Created a command to delete fake ProjectDownload instances

### DIFF
--- a/app/Console/Commands/DownloadProjects.php
+++ b/app/Console/Commands/DownloadProjects.php
@@ -8,6 +8,7 @@ use App\Models\ProjectDownload;
 use App\Models\ProjectPush;
 use App\Models\Task;
 use Illuminate\Console\Command;
+use Ramsey\Collection\Collection;
 
 class DownloadProjects extends Command
 {
@@ -42,7 +43,9 @@ class DownloadProjects extends Command
      */
     public function handle()
     {
-        $eligibleTasks = Task::whereIn('correction_type', ['manual'])->pluck('ends_at', 'id');
+        $eligibleTasks_DEPRECATED = Task::whereIn('correction_type', ['manual'])->pluck('ends_at', 'id'); // This is deprecated... But not removed yet TODO:Remove this line when all old tasks have been deleted
+        $eligibleTasks = Task::whereJsonContains("module_configuration->BuildTracking->enabled", true)->pluck('ends_at', 'id'); // This is the new way of doing it
+        $eligibleTasks->merge($eligibleTasks_DEPRECATED);
         $projects = Project::whereIn('task_id', $eligibleTasks->keys())->get();
         $queuedCount = ProjectDownload::queued()->count();
 

--- a/app/Console/Commands/RemoveFakeProjectDownload.php
+++ b/app/Console/Commands/RemoveFakeProjectDownload.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ProjectDownload;
+use App\Models\Task;
+use Illuminate\Console\Command;
+
+class RemoveFakeProjectDownload extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'task:RemoveFakeProjectDownload {task : The id of the task with broken downloads}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command will remove ProjectDownload instances from projects where the download was unsuccessful';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $taskID = $this->argument('task');
+        $task = Task::find($taskID);
+        if ( ! $task)
+        {
+            $this->error("Task {$taskID} not found.");
+
+            return Command::FAILURE;
+        }
+
+        $projects = $task->projects;
+        if ($projects->isEmpty())
+        {
+            $this->error("No projects found for task {$task->name} (id: {$taskID})");
+
+            return Command::FAILURE;
+        }
+        $hasDeletedAny = false;
+        foreach ($projects as $project)
+        {
+            if ( ! $project->download()->exists())
+            {
+                continue;
+            }
+
+            /** @var ProjectDownload $download */
+            $download = $project->download()->first();
+            $fileLocation = "tasks/{$project->task_id}/projects/{$project->id}_{$download->ref}";
+            if ( ! file_exists($fileLocation))
+            {
+                $this->info("Download not found for project {$project->id}... Deleting ProjectDownload");
+                $download->delete();
+                $hasDeletedAny = true;
+            }
+        }
+        if ($hasDeletedAny)
+        {
+            $this->warn("Fake downloads was found and has been deleted.\nIt is recommended to run the \"projects:download\" command to get them downloaded");
+        } else
+        {
+            $this->info("No fake downloads were found");
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Jobs/Project/DownloadProject.php
+++ b/app/Jobs/Project/DownloadProject.php
@@ -56,6 +56,8 @@ class DownloadProject implements ShouldQueue
             Log::error("Something went wrong while getting the archive of project {$this->download->project_id} with ref {$this->download->ref}", [
                 'exception' => $e,
             ]);
+            Log::info("Deleting ProjectDownload for project {$this->download->project_id} because the download was aborted");
+            $this->download->project->download()->delete();
 
             return;
         }

--- a/tests/Unit/App/Jobs/DownloadProjectJobTest.php
+++ b/tests/Unit/App/Jobs/DownloadProjectJobTest.php
@@ -144,13 +144,14 @@ it('should handle errors from GitLab API gracefully', function() {
         'queued_at'     => Carbon::now(),
     ])->for($this->project)->create();
 
+
     $this->mock(GitLabManager::class, function (MockInterface $mock) use ($projectDownload) {
         $mock->shouldReceive('repositories->archive')->once()->with($projectDownload->project->gitlab_project_id, [
             'sha' => $projectDownload->ref,
         ], 'zip')->andThrow(new \Exception('Mocked GitLab API error'));
     });
 
-    \Illuminate\Support\Facades\Log::shouldReceive('info')->once();
+    \Illuminate\Support\Facades\Log::shouldReceive('info')->twice();
     \Illuminate\Support\Facades\Log::shouldReceive('error')->once();
 
 
@@ -158,10 +159,7 @@ it('should handle errors from GitLab API gracefully', function() {
     $job->handle();
 
     // Assert
-    $projectDownload->refresh();
-    expect($projectDownload->location)->toBeNull();
-    expect($projectDownload->downloaded_at)->toBeNull();
-    expect($projectDownload->queued_at)->not()->toBeNull();
+    expect(ProjectDownload::find($projectDownload->id))->toBeNull();
 });
 
-?>
+


### PR DESCRIPTION
This will hopefully fix the bug with Scalable failing to download projects but beliving that they are downloaded