### PR TITLE
Fixed issue with project indexing

### DIFF
--- a/app/Jobs/Project/IndexRepositoryChanges.php
+++ b/app/Jobs/Project/IndexRepositoryChanges.php
@@ -64,7 +64,7 @@ class IndexRepositoryChanges implements ShouldQueue
         $accessToken = config('sourcecontrol.users.default.token');
         $sourceControlProject = $this->project->sourceControl();
         $url = Str::of($sourceControlProject->cloneUrl)->replace('://', "://:$accessToken@");
-        exec("docker run jazerix/git-diff:latest $url {$this->project->task->getSha()} $this->comparisonSha 2>&1", $output, $code);
+        exec("docker run madswp/git-diff-v2:latest $url {$this->project->task->getSha()} $this->comparisonSha 2>&1", $output, $code);
 
         $index = $index == null ? new ProjectDiffIndex() : $index;
         $index->project_id = $this->project->id;


### PR DESCRIPTION
Fixed the issue in #230 by updating to a new version of the git-diff image that does not have the problem with maximum size of 

(The repo for the image can be found here: [docker-git-diff](https://github.com/Darchie4/docker-git-diff))