### PR TITLE
Made Scalable more patient with GitLab (again)

### DIFF
--- a/app/Listeners/GitLab/Project/DisableForking.php
+++ b/app/Listeners/GitLab/Project/DisableForking.php
@@ -43,16 +43,15 @@ class DisableForking implements ShouldQueue
 
         Log::info("Disabling GitLab forking for project {$event->project->id}");
 
-        $attempts = 3;
+        $attempts = 5;
         $gitLabManager = app(GitLabManager::class);
         $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
 
         while (($project['import_error'] != null || $project['import_status'] != 'finished') && $attempts > 1)
         { // The system is sometimes too fast for the Gitlab server, this buys the Gitlab server some more time before Scalable moves on.
-            usleep(250000);
+            usleep(250_000);
             $attempts--;
             $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
-
         }
 
         if($project['import_error'] != null || $project['import_status'] != 'finished')

--- a/app/Listeners/GitLab/Project/DisableForking.php
+++ b/app/Listeners/GitLab/Project/DisableForking.php
@@ -43,13 +43,13 @@ class DisableForking implements ShouldQueue
 
         Log::info("Disabling GitLab forking for project {$event->project->id}");
 
-        $attempts = 5;
+        $attempts = 7;
         $gitLabManager = app(GitLabManager::class);
         $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
 
         while (($project['import_error'] != null || $project['import_status'] != 'finished') && $attempts > 1)
         { // The system is sometimes too fast for the Gitlab server, this buys the Gitlab server some more time before Scalable moves on.
-            usleep(250_000);
+            usleep(300_000);
             $attempts--;
             $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
         }

--- a/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
+++ b/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
@@ -44,14 +44,14 @@ class UnprotectDefaultBranch implements ShouldQueue
 
         $gitLabManager = app(GitLabManager::class);
 
-        $attempts = 3;
+        $attempts = 5;
 
         $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
 
 
         while (($project['import_error'] != null || $project['import_status'] != 'finished') && $attempts > 1)
         { // The system is sometimes too fast for the Gitlab server, this buys the Gitlab server some more time before Scalable moves on.
-            usleep(250000);
+            usleep(250_000);
             $attempts--;
             $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
 

--- a/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
+++ b/app/Listeners/GitLab/Project/UnprotectDefaultBranch.php
@@ -44,14 +44,14 @@ class UnprotectDefaultBranch implements ShouldQueue
 
         $gitLabManager = app(GitLabManager::class);
 
-        $attempts = 5;
+        $attempts = 7;
 
         $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
 
 
         while (($project['import_error'] != null || $project['import_status'] != 'finished') && $attempts > 1)
         { // The system is sometimes too fast for the Gitlab server, this buys the Gitlab server some more time before Scalable moves on.
-            usleep(250_000);
+            usleep(300_000);
             $attempts--;
             $project = $gitLabManager->projects()->show($event->project->gitlab_project_id);
 

--- a/tests/Unit/App/Jobs/DisableForkingJobTest.php
+++ b/tests/Unit/App/Jobs/DisableForkingJobTest.php
@@ -52,7 +52,7 @@ it('should throw an exception if the project import is not finished after 3 atte
     $this->project->save();
 
     $this->mock(GitLabManager::class, function (MockInterface $mock) {
-        $mock->shouldReceive('projects->show')->atMost()->times(3)->andReturn([
+        $mock->shouldReceive('projects->show')->atMost()->times(7)->andReturn([
             'import_error'  => 'error',
             'import_status' => 'finished',
         ]);

--- a/tests/Unit/App/Jobs/UnprotectDefaultBranchJobTest.php
+++ b/tests/Unit/App/Jobs/UnprotectDefaultBranchJobTest.php
@@ -52,7 +52,7 @@ it('should throw an exception if the project import is not finished after 3 atte
     $this->project->save();
 
     $this->mock(GitLabManager::class, function (MockInterface $mock) {
-        $mock->shouldReceive('projects->show')->atMost()->times(3)->andReturn([
+        $mock->shouldReceive('projects->show')->atMost()->times(7)->andReturn([
             'import_error'  => 'error',
             'import_status' => 'finished',
         ]);


### PR DESCRIPTION
This PR fixes issue #245 by making Scalable accept waiting for up to 2.1 seconds for GitLab to create a project. 
This is a balancing act since setting the sleep time too high makes the system feel slower and setting the attempts higher makes Scalable spam the GitLab server.